### PR TITLE
Remove ensure_gn_version

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -3027,19 +3027,19 @@ hooks = [
         'src/tools',
     ],
   },
-  {
+  #{
     # Verify that we have the right GN binary and force-install it if we
     # don't, in order to work around crbug.com/944367.
     # TODO(crbug.com/944667) Get rid of this when cipd is ensuring we
     # have the right binary more carefully and we no longer need this.
-    'name': 'ensure_gn_version',
-    'pattern': '.',
-    'action': [
-      'python',
-      'src/buildtools/ensure_gn_version.py',
-      Var('gn_version')
-    ],
-  },
+  #  'name': 'ensure_gn_version',
+  #  'pattern': '.',
+  #  'action': [
+  #    'python',
+  #    'src/buildtools/ensure_gn_version.py',
+  #    Var('gn_version')
+  #  ],
+  #},
   {
     # This downloads binaries for Native Client's newlib toolchain.
     # Done in lieu of building the toolchain from scratch as it can take


### PR DESCRIPTION
Fixes issue with gn exec format error (part of https://github.com/leo-lb/electron/issues/1) which occurs during gn version check on ppc64le.